### PR TITLE
Travis CI & Docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,55 @@
+language: java
+dist: bionic
+
+jdk: openjdk8
+
+addons:
+  apt:
+    packages:
+      - python3-pip
+      - python3-setuptools
+
+# Required by test script for determining which tests to run based on Git changes
+git:
+  depth: false
+
+# Note: .travis/set_env.sh exports some environment variables *common* to build deploy steps
+before_install:
+  - source .travis/set_env.sh
+  - python3 -m pip install -r dev/requirements.txt
+
+before_deploy:
+  - source .travis/set_env.sh
+  - .travis/check_tag.sh
+  - docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+
+script: .travis/build.sh $SPARK_IMAGE_NAME
+
+deploy:
+  # Push a Docker image for long lived version branches (e.g. 'branch-2.4', 'branch-3.0')
+  # OR git tags (e.g. our patched 'release" of an upstream version)
+  - provider: script
+    skip_cleanup: true
+    script:
+      - docker push $IMAGE_NAME
+    on:
+      condition: ${TRAVIS_BRANCH} =~ branch-.+ || -n ${TRAVIS_TAG}
+  # Add the Spark distribution package to GitHub release assets
+  - provider: releases
+    skip_cleanup: true
+    api_key:
+      # FIXME: This is tied to github.com/SteadBytes account and should use a github.com/unipartdigital bot API Key
+      secure: j4K57og6HF5bxSPGZ7MbxDXpA46v7wFoPMYDAIjeEQ8YOZ7t43WTcyu/c/K9/ME5vZP/MclzdcbvTttJEEt7uKsZsSuXuLez2OYbc1NyAZaRjs7LRAaBP5Otl/TQQyCebGeLiNz9CVPgTIPwu/Q1XWuJ7rOGNPo1b8EUaCBqvDLDR4LQf6Pvvc87Tuad89+DCZ3losegUxEzWNQk0rmwW76VOaOlbxL+wy8J38vNHs9BTgjOKR+HPV98QdV8eTxbNCDsMbq8tPuKOM8KdPcQEHnoC5Bod0jzfG9IqUiTlxav2qGUFh5nq7tW7ObUpPGsI4FSbiwZLwTF/qzcM9Fg6sTEg3bP/3wcrAqNf0fhEmYGeOosPiVnX8D2QvpeHSQ/WSPSCYKc9NbxCwmD1F5a8pKiZnWUn9mCxylLf7qkrRJfK18YOaEVmDXYjOJpODIEneCtNNVATr9IlQt40xBbrEB6krPWyqUPXLa798/GLAe9ZcPTs4d9AyNSHShYslrm1VMWSaZKAJ4nYAA9KCETQ8dWOQiqa59Bmbg/9v3EcQfOyAB30o+kbCX8pa2zEwveGcBH+EdZb0qxLjGkg+YFnQVqOJzLGwx6Wlp10fx4nkv6d/yop3HY0D8u/H15Gi9UWGai3asv83El7eSRx41CRRoNrMpLycmomwvGippKcPQ=
+    file: spark-*.tgz
+    on:
+      tags: true
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+    - $HOME/.m2

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+usage() {
+    cat <<EOF
+    Usage: $0 IMAGE"
+    Build Spark distribution package and build a Docker image IMAGE
+EOF
+}
+
+if [ $# -ne 1 ]; then
+  usage
+  exit 1
+fi
+
+image="$1"
+
+echo "Running tests"
+./dev/run-tests
+
+echo "Building distribution package"
+./dev/make-distribution.sh \
+  --pip --tgz \
+  # Build flags specified in the RELEASE file of https://downloads.apache.org/spark/spark-2.4.5/spark-2.4.5-bin-hadoop2.7.tgz
+  -Pmesos -Pyarn -Pkubernetes -Pflume -Psparkr -Pkafka-0-8 -Phadoop-2.7 -Phive -Phive-thriftserver
+
+echo "Building Docker image $image"
+docker build -t $image .

--- a/.travis/check_tag.sh
+++ b/.travis/check_tag.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# If this is a tag release, ensure that the Spark version and tag name match.
+
+set -e
+
+if [ -z "$TRAVIS_TAG" ] && [ "$TRAVIS_TAG" != "$SPARK_PACKAGE_VERSION" ]
+  then
+    echo "Tag name does not match Spark version"
+    exit 1;
+fi

--- a/.travis/set_env.sh
+++ b/.travis/set_env.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Set up environment variables used in .travis.yml config
+set -e
+
+export SPARK_PACKAGE_VERSION=$(mvn help:evaluate -Dexpression=project.version $@ 2>/dev/null\
+      | grep -v "INFO"\
+      | grep -v "WARNING"\
+      | tail -n 1)
+export SPARK_IMAGE_NAME="$TRAVIS_REPO_SLUG":"$PACKAGE_VERSION"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+# Start with Python base as reliably installing the same Python version e.g not
+# just 'python3' package) is more work than installing openjdk8 correctly
+FROM python:3.7-alpine
+
+# Path to Spark dist package to copy into container
+# built with ./dev/make-distribution.sh --tgz <other args>
+ARG SPARK_PACKAGE
+ARG SPARK_HOME=/opt/spark
+ARG SPARK_USER=spark
+ARG SPARK_GROUP=spark
+ARG UID=1001
+ARG GID=1001
+
+ENV SPARK_HOME=${SPARK_HOME}
+ENV SPARK_LOG_DIR=${SPARK_HOME}/logs
+ENV PATH="${SPARK_HOME}/bin:${SPARK_HOME}:sbin:$PATH"
+
+RUN echo "==> Updating distro packages..."  \
+    && apk update \
+    && echo "==> Installing dependencies..." \
+    && apk add --no-cache \
+     openjdk8-jre \
+     # Required by Spark scripts for additional flags/options
+     bash procps coreutils
+
+RUN echo "==> Setting up users and groups..." \
+    && addgroup ${SPARK_GROUP} \
+        --gid "$GID" \
+    && adduser \
+        --disabled-password \
+        --home "$(pwd)" \
+        --ingroup ${SPARK_GROUP} \
+        # Enable
+        --ingroup tty \
+        --uid "$UID" \
+        --no-create-home \
+        ${SPARK_USER}
+
+RUN echo "==> Setting up SPARK_HOME..." \
+    && mkdir -p ${SPARK_HOME} \
+    && chown -R ${SPARK_USER}:${SPARK_GROUP} ${SPARK_HOME} \
+    && chmod -R 755 ${SPARK_HOME}
+
+COPY run.sh /
+RUN chmod +x /run.sh
+
+COPY ${SPARK_PACKAGE} /tmp
+
+WORKDIR ${SPARK_HOME}
+
+RUN echo "==> Unpacking Spark package ${SPARK_PACKAGE} to ${SPARK_HOME}" \
+    && tar -xvzf /tmp/${SPARK_PACKAGE} --strip-components=1
+
+# Non-root
+USER ${SPARK_USER}
+
+CMD ["/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@
 # just 'python3' package) is more work than installing openjdk8 correctly
 FROM python:3.7-alpine
 
-# Path to Spark dist package to copy into container
-# built with ./dev/make-distribution.sh --tgz <other args>
-ARG SPARK_PACKAGE
 ARG SPARK_HOME=/opt/spark
 ARG SPARK_USER=spark
 ARG SPARK_GROUP=spark
@@ -41,15 +38,13 @@ RUN echo "==> Setting up SPARK_HOME..." \
     && chown -R ${SPARK_USER}:${SPARK_GROUP} ${SPARK_HOME} \
     && chmod -R 755 ${SPARK_HOME}
 
+COPY dist/* ${SPARK_HOME}
+
 COPY run.sh /
 RUN chmod +x /run.sh
 
-COPY ${SPARK_PACKAGE} /tmp
 
 WORKDIR ${SPARK_HOME}
-
-RUN echo "==> Unpacking Spark package ${SPARK_PACKAGE} to ${SPARK_HOME}" \
-    && tar -xvzf /tmp/${SPARK_PACKAGE} --strip-components=1
 
 # Non-root
 USER ${SPARK_USER}

--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -1,3 +1,10 @@
+# Not intended to be upstreamed
+Dockerfile
+docker-compose.yml
+run.sh
+.travis.yml
+.travis/*
+
 target
 cache
 .gitignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+# Example docker-compose configuration for a small Spark cluster
+version: '2.4'
+
+services:
+  spark:
+    image: unipartdigital/spark
+    environment:
+      - SPARK_MODE=master
+      - SPARK_RPC_AUTHENTICATION_ENABLED=no
+      - SPARK_RPC_ENCRYPTION_ENABLED=no
+      - SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED=no
+      - SPARK_SSL_ENABLED=no
+    ports:
+      - '8080:8080'
+  spark-worker-1:
+    image: unipartdigital/spark
+    environment:
+      - SPARK_MODE=worker
+      - SPARK_MASTER_URL=spark://spark:7077
+      - SPARK_WORKER_MEMORY=1G
+      - SPARK_WORKER_CORES=1
+  spark-worker-2:
+    image: unipartdigital/spark
+    environment:
+      - SPARK_MODE=worker
+      - SPARK_MASTER_URL=spark://spark:7077
+      - SPARK_WORKER_MEMORY=1G
+      - SPARK_WORKER_CORES=1

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Load Spark env vars
+. spark-config.sh
+. load-spark-env.sh
+
+export SPARK_NO_DAEMONIZE=1
+
+if [ "$SPARK_MODE" == "master" ]; then
+    log=spark-master.out
+    cmd=start-master.sh
+    args=()
+    echo "==> Starting Spark in master mode"
+else
+    log=spark-worker.out
+    cmd=start-slave.sh
+    args=("$SPARK_MASTER_URL")
+    echo "==> Starting Spark in worker mode"
+fi
+
+mkdir -p $SPARK_LOG_DIR
+ln -sf /dev/stdout $SPARK_LOG_DIR/$log
+
+exec "$cmd" "${args[@]}" >> $SPARK_LOG_DIR/$log


### PR DESCRIPTION
- Run Spark test suite on all branches
  - Not including the full integration tests as this takes *hours* (see upstream
    Spark Jenkins build server for examples)
- Build a full distributable Spark package on all branches
- Push a `unipartdigital/spark:<branch-name>` Docker image for long lived
  branches
    - `branch-2.4`, `branch-3.0` etc.
- Push a `unipartdigital/spark:<version>` Docker image for tag releases
  - `<version>` specified in `pom.xml` **must** match the tag name otherwise
    the build will fail
- Upload the Spark distributable package `.tgz` as an assets for tag
  releases